### PR TITLE
型定義をPublicにする

### DIFF
--- a/webapp/go/Makefile
+++ b/webapp/go/Makefile
@@ -1,0 +1,2 @@
+isuports: go.mod go.sum *.go cmd/isuports/*
+	go build -o isuports ./cmd/isuports

--- a/webapp/go/cmd/isuports/main.go
+++ b/webapp/go/cmd/isuports/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	isuports "github.com/isucon/isucon12-qualify/webapp/go"
+)
+
+func main() {
+	isuports.Run()
+}

--- a/webapp/go/isuports.go
+++ b/webapp/go/isuports.go
@@ -1,4 +1,4 @@
-package main
+package isuports
 
 import (
 	"context"
@@ -91,7 +91,7 @@ func dispenseID(ctx context.Context) (int64, error) {
 
 var centerDB *sqlx.DB
 
-func main() {
+func Run() {
 	e := echo.New()
 	e.Debug = true
 	e.Logger.SetLevel(log.DEBUG)


### PR DESCRIPTION
ベンチマーカーやダミーデータ生成でも使いたいため