### PR TITLE
nginx.confのupstreamはlink nameではなくIPアドレスにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,7 @@ services:
       #- ./public:/public
     ports:
       - "80:80"
-    links:
-      - webapp
-      - blackauth
+    network_mode: host
     restart: always
 
   blackauth:
@@ -18,6 +16,8 @@ services:
     environment:
       ISUCON_BASE_HOSTNAME: .t.isucon.dev
       ISUCON_ADMIN_HOSTNAME: admin.t.isucon.dev
+    ports:
+      - "3001:3001"
     init: true
     restart: always
 
@@ -33,6 +33,8 @@ services:
       ISUCON_DB_NAME: isuports
       ISUCON_BASE_HOSTNAME: .t.isucon.dev
       ISUCON_ADMIN_HOSTNAME: admin.t.isucon.dev
+    ports:
+      - "3000:3000"
     links:
       - mysql
     volumes:

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -5,19 +5,19 @@ server {
 
   location / {
     proxy_set_header Host $host;
-    proxy_pass http://webapp:3000;
+    proxy_pass http://127.0.0.1:3000;
   }
 
   location = /api/player/login {
     proxy_set_header Host $host;
-    proxy_pass http://blackauth:3001;
+    proxy_pass http://127.0.0.1:3001;
   }
   location = /api/organizer/login {
     proxy_set_header Host $host;
-    proxy_pass http://blackauth:3001;
+    proxy_pass http://127.0.0.1:3001;
   }
   location = /api/admin/login {
     proxy_set_header Host $host;
-    proxy_pass http://blackauth:3001;
+    proxy_pass http://127.0.0.1:3001;
   }
 }


### PR DESCRIPTION
- benchだけでなくnginxも network_mode: host にする
- nginxからは 127.0.0.1:3000 (webapp) と 127.0.0.1:3001 (blackauth) にリバースプロキシする

これで nginxのdefault.conf には名前解決がなくなったので、EC2つくるときの /etc/nginx/conf.d/default.conf としてそのままお使いいただけます