### PR TITLE
Request().Context() をやめる

### DIFF
--- a/webapp/go/isuports.go
+++ b/webapp/go/isuports.go
@@ -827,7 +827,7 @@ func competitionFinishHandler(c echo.Context) error {
 }
 
 func competitionResultHandler(c echo.Context) error {
-	ctx := c.Request().Context()
+	ctx := context.Background()
 	if v, err := parseViewer(c); err != nil {
 		return fmt.Errorf("error parseViewer: %w", err)
 	} else if v.role != RoleOrganizer {
@@ -950,7 +950,7 @@ type BillingHandlerResult struct {
 }
 
 func billingHandler(c echo.Context) error {
-	ctx := c.Request().Context()
+	ctx := context.Background()
 	if v, err := parseViewer(c); err != nil {
 		return fmt.Errorf("error parseViewer: %w", err)
 	} else if v.role != RoleOrganizer {
@@ -1019,7 +1019,7 @@ type PlayerHandlerResult struct {
 }
 
 func playerHandler(c echo.Context) error {
-	ctx := c.Request().Context()
+	ctx := context.Background()
 
 	v, err := parseViewer(c)
 	if err != nil {
@@ -1114,7 +1114,7 @@ type CompetitionRankingHandlerResult struct {
 }
 
 func competitionRankingHandler(c echo.Context) error {
-	ctx := c.Request().Context()
+	ctx := context.Background()
 	v, err := parseViewer(c)
 	if err != nil {
 		return fmt.Errorf("error parseViewer: %w", err)
@@ -1143,7 +1143,7 @@ func competitionRankingHandler(c echo.Context) error {
 		return fmt.Errorf("error retrieveCompetition: %w", err)
 	}
 
-	vp, err := retrievePlayer(c.Request().Context(), tenantDB, v.playerID)
+	vp, err := retrievePlayer(ctx, tenantDB, v.playerID)
 	if err != nil {
 		return fmt.Errorf("error retrievePlayer from viewer: %w", err)
 	}
@@ -1223,7 +1223,7 @@ type CompetitionsHandlerResult struct {
 }
 
 func competitionsHandler(c echo.Context) error {
-	ctx := c.Request().Context()
+	ctx := context.Background()
 
 	v, err := parseViewer(c)
 	if err != nil {
@@ -1240,7 +1240,7 @@ func competitionsHandler(c echo.Context) error {
 	}
 	defer tenantDB.Close()
 
-	vp, err := retrievePlayer(c.Request().Context(), tenantDB, v.playerID)
+	vp, err := retrievePlayer(ctx, tenantDB, v.playerID)
 	if err != nil {
 		return fmt.Errorf("error retrievePlayer from viewer: %w", err)
 	}


### PR DESCRIPTION
ベンチ終了時、クライアントが切断するとサーバー側のrequest contextもcancelされてクエリが中断したりエラーログが大量にでたりするので、requestのcontextを引き回すのをやめます。