### PR TITLE
Fix faker

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -294,14 +294,14 @@ func CreateTenant(isFirst bool) *isuports.TenantRow {
 	if isFirst {
 		// これだけ特別
 		created = Epoch
-		name, displayName = "isucon", "ISUCONglomerate"
+		name, displayName = "isucon", "ISUコングロマリット"
 	} else {
 		created = fake.Time().TimeBetween(
 			Epoch.Add(time.Duration(id)*time.Hour*3),
 			Epoch.Add(time.Duration(id+1)*time.Hour*3),
 		)
 		name = fmt.Sprintf("%s-%d", fake.Internet().Slug(), id)
-		displayName = fake.Company().Name()
+		displayName = FakeTenantName()
 	}
 	tenant := isuports.TenantRow{
 		ID:          id,
@@ -366,7 +366,7 @@ func CreateCompetition(tenant *isuports.TenantRow) *isuports.CompetitionRow {
 	competition := isuports.CompetitionRow{
 		TenantID:  tenant.ID,
 		ID:        strconv.FormatInt(GenID(created), 10),
-		Title:     fake.Music().Name(),
+		Title:     FakeCompetitionName(),
 		CreatedAt: created,
 	}
 	if isFinished {

--- a/data/rand.go
+++ b/data/rand.go
@@ -3,6 +3,7 @@ package data
 import (
 	crand "crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -42,16 +43,41 @@ func UniqueRandomString(n int) string {
 
 // https://github.com/isucon/isucon10-final/blob/b2d2291d9938fefc879a6c8a2f65bd6335f2b873/benchmarker/random/team_name.go
 
-func TeamName() string {
-	return generatePrefix1() + generatePrefix2() + generateMiddle() + generateSuffix()
+func FakeCompetitionName() string {
+	p := generateCompetitionPrefix()
+	if p == "" {
+		return p + generatePrefix2() + generateMiddle() + generateSuffix() + generateCompetitionSuffix()
+	} else {
+		return p + generatePrefix2() + generateMiddle() + generateSuffix()
+	}
 }
 
-func generatePrefix1() string {
+func FakeTenantName() string {
+	return generateTenantPrefix() + generatePrefix2() + generateMiddle() + generateSuffix()
+}
+
+func generateTenantPrefix() string {
 	if rand.Intn(10) < 2 {
-		return "大会"
+		return "チーム"
 	} else {
 		return ""
 	}
+}
+
+func generateCompetitionPrefix() string {
+	if n := rand.Intn(40); n != 0 && n < 10 {
+		return fmt.Sprintf("第%d回 ", n)
+	} else {
+		return ""
+	}
+}
+
+func generateCompetitionSuffix() string {
+	return []string{"杯", "カップ", "大会",
+		fmt.Sprintf(" vol.%d", rand.Intn(10)),
+		fmt.Sprintf(" #%d", rand.Intn(10)),
+		"",
+	}[rand.Intn(6)]
 }
 
 var prefix2Data = []string{


### PR DESCRIPTION
テナント名の例
```
mysql> select display_name from tenant;
+--------------------------------------------------------------+
| display_name                                                 |
+--------------------------------------------------------------+
| ISUコングロマリット                                          |
| チームマネージド吉祥寺一択                                   |
| リアル洋梨ず                                                 |
| 南相撲倶楽部                                                 |
| じゃがいも堂                                                 |
| ボルダリングこわれました                                     |
| 朝までエール同位体                                           |
| 朝までHTTP/2ドーナツ                                         |
| チームソフトウェア研究所                                     |
| ウェブスケール二子玉川（仮）                                 |
| 実用段階きゅうりの缶詰                                       |
| 無農薬さくらんぼでごめん                                     |
| 聖なるペットボトルだねえ                                     |
| 並行チューリップ高校                                         |
| 夏のマンゴーラボ                                             |
```

大会名の例
```
sqlite> select title from competition;
プロファイリングの惨劇 #1
ランブータンください #9
第8回 おしなべてラズベリー探偵
苦みオンライン #4
ミックス野郎大会
柏賛歌
第7回 ミックス乗り過ごし
おしゃれ広尾合衆国カップ
無限町田.dev vol.6
ミルク戦線 #0
実はツナ鎮魂歌
箱出し酎ハイ卒カップ
町田フォビアカップ
第9回 並行青山一丁目基地
たべられない柏の上の刺身大会
第6回 上野づくし
やわやわパワー出張所
第5回 立川大学
第3回 影の広尾は命より重い
ゆっくりデータベース.dev
```