### PR TITLE
full testにcore2ラベルを追加

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -53,11 +53,12 @@ jobs:
         run: |
           make ci
 
-      - name: "前ベンチが完全にタイムアウトするまで少しだけ待つ"
-        run: |
-          sleep 5
+      # 2coreのself hosted runnerに限りがあるので一時コメントアウト
+      # - name: "前ベンチが完全にタイムアウトするまで少しだけ待つ"
+      #   run: |
+      #     sleep 5
 
-      - name: "run bench(load-type light)"
-        working-directory: ./bench
-        run: |
-          make ci-loadtype-light
+      # - name: "run bench(load-type light)"
+      #   working-directory: ./bench
+      #   run: |
+      #     make ci-loadtype-light


### PR DESCRIPTION
```
Current runner version: '2.294.0'
Runner name: 'self-hosted-runner-3'
Runner group name: 'Default'
Machine name: 'self-hosted-runner-[3](https://github.com/isucon/isucon12-qualify/runs/7104941397?check_suite_focus=true#step:1:3)'
```

self-hosted-runner-3 が2 coreとのことで正しく動いてそうです