### PR TITLE
admin billingの最大を10件に減らす

### DIFF
--- a/bench/scenario_validation.go
+++ b/bench/scenario_validation.go
@@ -483,10 +483,11 @@ func (sc *Scenario) ValidationScenario(ctx context.Context, step *isucandar.Benc
 	{
 		// ページング無しで今回操作したテナントが含まれていることを確認
 		res, err := GetAdminTenantsBillingAction(ctx, "", adminAg)
-		v := ValidateResponse("テナント別の請求ダッシュボード", step, res, err, WithStatusCode(200),
+		v := ValidateResponse("テナント別の請求ダッシュボード(最大10件)", step, res, err, WithStatusCode(200),
 			WithSuccessResponse(func(r ResponseAPITenantsBilling) error {
-				if 1 > len(r.Data.Tenants) {
-					return fmt.Errorf("請求ダッシュボードの結果がありません")
+				// 初期データがあるので上限ま取ってこれる
+				if 10 != len(r.Data.Tenants) {
+					return fmt.Errorf("請求ダッシュボードの結果の数が違います (want: %d, got: %d)", len(r.Data.Tenants), 10)
 				}
 				tenantNameMap := make(map[string]struct{})
 				for _, tenant := range r.Data.Tenants {

--- a/webapp/go/isuports.go
+++ b/webapp/go/isuports.go
@@ -713,7 +713,7 @@ func tenantsBillingHandler(c echo.Context) error {
 			tb.BillingYen += report.BillingYen
 		}
 		tenantBillings = append(tenantBillings, tb)
-		if len(tenantBillings) >= 20 {
+		if len(tenantBillings) >= 10 {
 			break
 		}
 	}


### PR DESCRIPTION
id=1(ISUコングロマリット)に届く前に30sかかってタイムアウトするので、最大を20件から10件に減らす

```
 % cat access.log | alp ltsv -m '/api/player/player/.+,/api/organizer/player/.+/disqualified,/api/organizer/competition/.+/result,/api/organizer/competition/.+/finish,/api/player/competition/.+/ranking' -o "count,2xx,4xx,5xx,method,uri,min,avg,p99,max,sum"

+-------+-----+-----+-----+--------+---------------------------------------+-------+--------+--------+--------+----------+
| COUNT | 2XX | 4XX | 5XX | METHOD |                  URI                  |  MIN  |  AVG   |  P99   |  MAX   |   SUM    |
+-------+-----+-----+-----+--------+---------------------------------------+-------+--------+--------+--------+----------+
|     1 |   1 |   0 |   0 | POST   | /initialize                           | 2.953 |  2.953 |  2.953 |  2.953 |    2.953 |
|     3 |   3 |   0 |   0 | POST   | /api/organizer/players/add            | 0.133 |  0.950 |  2.147 |  2.147 |    2.849 |
|     5 |   2 |   3 |   0 | POST   | /api/admin/tenants/add                | 0.003 |  0.033 |  0.132 |  0.132 |    0.167 |
|     6 |   6 |   0 |   0 | GET    | /api/organizer/billing                | 0.011 |  0.447 |  1.828 |  1.828 |    2.683 |
|     6 |   5 |   1 |   0 | GET    | /api/admin/tenants/billing            | 3.958 | 10.901 | 19.773 | 19.773 |   65.405 |
|     8 |   7 |   1 |   0 | POST   | /api/organizer/competition/.+/finish  | 0.004 |  0.017 |  0.045 |  0.045 |    0.133 |
|    12 |  11 |   1 |   0 | POST   | /api/organizer/competitions/add       | 0.004 |  0.048 |  0.240 |  0.240 |    0.580 |
|    29 |  23 |   6 |   0 | POST   | /api/organizer/competition/.+/result  | 0.004 |  5.967 | 29.997 | 29.997 |  173.051 |
|    46 |  45 |   1 |   0 | POST   | /api/organizer/player/.+/disqualified | 0.007 |  0.038 |  1.103 |  1.103 |    1.737 |
|    54 |  54 |   0 |   0 | GET    | /api/organizer/players                | 0.006 |  0.030 |  0.892 |  0.892 |    1.608 |
|   147 | 102 |  45 |   0 | GET    | /api/player/competitions              | 0.003 |  0.353 |  1.188 |  1.214 |   51.820 |
|   275 | 258 |  17 |   0 | GET    | /api/player/competition/.+/ranking    | 0.004 |  4.648 | 14.538 | 25.282 | 1278.103 |
|   898 | 811 |  87 |   0 | GET    | /api/player/player/.+                 | 0.004 |  4.964 | 20.255 | 25.875 | 4457.853 |
+-------+-----+-----+-----+--------+---------------------------------------+-------+--------+--------+--------+----------+
```

admin/tenants/billingに余裕が出た
