### PR TITLE
fix mysql-client install error for apple silicon

### DIFF
--- a/development/backend-go/Dockerfile
+++ b/development/backend-go/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
   wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
-  apt-get -y install mysql-client
+  apt-get -y install mariadb-client
 
 RUN curl -sLO https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.tar.gz && \
   tar xf gh_2.13.0_linux_amd64.tar.gz && \


### PR DESCRIPTION
m1 mac環境下において make up/goでerror

```
 => ERROR [development_bench  9/13] RUN apt-get -y install mysql-client                                                                                                      0.9s
------
 > [development_bench  9/13] RUN apt-get -y install mysql-client:
#0 0.206 Reading package lists...
#0 0.479 Building dependency tree...
#0 0.548 Reading state information...
#0 0.558 Package mysql-client is not available, but is referred to by another package.
#0 0.558 This may mean that the package is missing, has been obsoleted, or
#0 0.558 is only available from another source
#0 0.558
#0 0.599 E: Package 'mysql-client' has no installation candidate
------
failed to solve: executor failed running [/bin/sh -c apt-get -y install mysql-client]: exit code: 100
make: *** [up/go] Error 17
```

intel mac では問題無し


https://stackoverflow.com/questions/57048428/e-package-mysql-client-has-no-installation-candidate-in-php-fpm-image-build-u

