### PR TITLE
fix(go): Always rebuild webapp container in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           make initial_data
           make down/go
-          make up/go OPT=-d
+          make up/go OPT='-d --build'
           make install_initial_data
         working-directory: ./development
         env:


### PR DESCRIPTION
CI で言語毎に docker-compose-${lang}.yml を差し換えることで webapp のコンテナを差し換えてますが、`--build` を渡さないと直前の CI 実行時に使われていた webapp のコンテナがそのまま使われてしまい正しくベンチマーク実行できないので、Go 版の workflow に `OPT='-d --build'` を足しました。
https://github.com/isucon/isucon12-qualify/pull/135#issuecomment-1184721815