### PR TITLE
remove workdir before checkout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,7 @@ jobs:
       - name: cleanup
         run: |
           sudo rm -fr /home/github/work/isucon12-qualify/isucon12-qualify
+          mkdir /home/github/work/isucon12-qualify/isucon12-qualify
 
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
rootユーザーでworking tree以下にファイルを作ってしまうと次回のcheckoutで消せなくて困るので、事前にsudoで全部消しておく