### PR TITLE
/api/me で非認証の場合は401を返す

### DIFF
--- a/webapp/go/isuports.go
+++ b/webapp/go/isuports.go
@@ -1529,19 +1529,7 @@ func meHandler(c echo.Context) error {
 	}
 	v, err := parseViewer(c)
 	if err != nil {
-		var he *echo.HTTPError
-		if ok := errors.As(err, &he); ok && he.Code == http.StatusUnauthorized {
-			return c.JSON(http.StatusOK, SuccessResult{
-				Success: true,
-				Data: MeHandlerResult{
-					Tenant:   td,
-					Me:       nil,
-					Role:     RoleNone,
-					LoggedIn: false,
-				},
-			})
-		}
-		return fmt.Errorf("error parseViewer: %w", err)
+		return err
 	}
 	if v.role == RoleAdmin || v.role == RoleOrganizer {
 		return c.JSON(http.StatusOK, SuccessResult{


### PR DESCRIPTION
401を返す場合、tenant.DisplayNameは返せないのでクライアントでは表示できない

https://github.com/isucon/isucon12-qualify/pull/135/files#r918165445
parseViwerで401が出たら(trapして200にするのではなく)単にそれを返したい、という要請。