### PR TITLE
fix(rust) 開発用にビルドキャッシュが使えるようにtarget以下をdocker volumeとする

### DIFF
--- a/development/backend-rust/Dockerfile
+++ b/development/backend-rust/Dockerfile
@@ -14,14 +14,7 @@ RUN curl -sLO https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_lin
     tar xf gh_2.13.0_linux_amd64.tar.gz && \
     install gh_2.13.0_linux_amd64/bin/gh /usr/local/bin
 
-WORKDIR /home/isucon/webapp
-RUN cargo new --bin rust
-WORKDIR ./rust
-COPY ./webapp/rust/Cargo.toml ./Cargo.toml
-RUN cargo build --release
-RUN rm -rf src
-COPY ./webapp/rust/src /home/isucon/webapp/rust/src
-RUN cargo build
-CMD [ "./target/debug/isuports" ]
+WORKDIR /home/isucon/webapp/rust
+CMD [ "cargo", "run" ]
 
 

--- a/development/docker-compose-rust.yml
+++ b/development/docker-compose-rust.yml
@@ -22,9 +22,11 @@ services:
       - ../webapp:/home/isucon/webapp
       - tenant_db:/home/isucon/webapp/tenant_db
       - initial_data:/home/isucon/initial_data
+      - target:/home/isucon/webapp/rust/target
     init: true
     restart: always
 
 volumes:
+  target:
   tenant_db:
   initial_data:

--- a/webapp/rust/src/main.rs
+++ b/webapp/rust/src/main.rs
@@ -18,7 +18,7 @@ use actix_multipart::Multipart;
 use futures_util::stream::StreamExt as _;
 
 const TENANT_DB_SCHEMA_FILE_PATH: &str = "../sql/tenant/10_schema.sql";
-const INITIALIZE_SCRIPT: &str = "..sql/init.sh";
+const INITIALIZE_SCRIPT: &str = "../sql/init.sh";
 const COOKIE_NAME: &str = "isuports_session";
 
 const ROLE_ADMIN: &str = "admin";


### PR DESCRIPTION
### 解決したいこと

* rustの参考実装を変えるたびにビルドに時間がかかる
  * docker build時に`cargo build --relase`で都度依存crateを取得し、フルビルドしているため

### 行ったこと

* `/home/isucon/webapp/rust/target`以下をdocker volumeとする
* CMDで`cargo run`と実行時にビルドを行うようにする
  * docker build時にはvolume mountは使われないため