### PR TITLE
テナントの請求の計算のコメントが古かったのを修正

### DIFF
--- a/webapp/go/isuports.go
+++ b/webapp/go/isuports.go
@@ -644,8 +644,8 @@ func tenantsBillingHandler(c echo.Context) error {
 	}
 	// テナントごとに
 	//   大会ごとに
-	//     scoreに登録されているplayer * 100
-	//     scoreに登録されていないplayerでアクセスした人 * 10
+	//     scoreが登録されているplayer * 100
+	//     scoreが登録されていないplayerでアクセスした人 * 10
 	//   を合計したものを
 	// テナントの課金とする
 	ts := []TenantRow{}


### PR DESCRIPTION
https://isucon.slack.com/archives/C0361TFRMC6/p1657983228081299

* 計算式が スコア登録している人 * 100 + 閲覧だけした人 * 10 になっているので、コメントを修正しました