### PR TITLE
roleがいずれかにも当てはまらない場合のエラーログに常にゼロ値のものが含まれているのでエラーログからなくした

### DIFF
--- a/webapp/go/isuports.go
+++ b/webapp/go/isuports.go
@@ -283,7 +283,7 @@ func parseViewer(c echo.Context) (*Viewer, error) {
 	default:
 		return nil, echo.NewHTTPError(
 			http.StatusUnauthorized,
-			fmt.Sprintf("invalid token: %s is invalid role", tokenStr),
+			fmt.Sprintf("invalid token: invalid role: %s", tokenStr),
 		)
 	}
 	// aud は1要素でテナント名がはいっている


### PR DESCRIPTION
https://github.com/isucon/isucon12-qualify/pull/108#discussion_r921368486
の指摘

* `tokenStr`だけあれば十分と思われるので、エラーメッセージを変えました