### PR TITLE
レースコンディションでエラーになる組み合わせが初期実装にあるのでコメントで言っておく

### DIFF
--- a/webapp/go/isuports.go
+++ b/webapp/go/isuports.go
@@ -489,8 +489,8 @@ func tenantsAddHandler(c echo.Context) error {
 		return fmt.Errorf("error get LastInsertId: %w", err)
 	}
 	// NOTE: 先にadminDBに書き込まれることでこのAPIの処理中に
-	//       /api/admin/tenants/billingにアクセスされるとエラーになる
-	//       ロックなどで対処する
+	//       /api/admin/tenants/billingにアクセスされるとエラーになりそう
+	//       ロックなどで対処したほうが良さそう
 	if err := createTenantDB(id); err != nil {
 		return fmt.Errorf("error createTenantDB: id=%d name=%s %w", id, name, err)
 	}


### PR DESCRIPTION
https://isucon.slack.com/archives/C0361TFRMC6/p1658223608145029 この辺から

* 初期実装では`/api/admin/tenants/add` をしている間に `/api/admin/tenants/billing`にアクセスすると500エラーになる
  * ID発番の関係上adminDBにINSERT後にDBを作成しているため
  * トランザクションを使えばよいが、初期実装はトランザクションを知らない体で書いている
* インデックスを貼るなど高速化するとベンチがfailする影響が出てくるので、直さずにコメントで補足しておく
  * いわゆるrace-conditionなのでちょっとわかりにくい