### PR TITLE
[bench] 実装ミス、表記ゆれの修正

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -22,6 +22,8 @@ Usage of bench:
         Initialize request timeout (default 30s)
   -prepare-only
         Prepare only
+  -reproduce
+        reproduce contest day mode. default: false
   -request-timeout duration
         Default request timeout (default 30s)
   -skip-prepare
@@ -88,3 +90,9 @@ job_xxx
 - 終わるまでブロックする
 - Scenarioの中で利用する
 
+
+### Reproduce mode（コンテスト当日の再現について）
+
+負荷走行の一部で本来意図していない挙動をしていた点について、競技終了後に修正を行いました。  
+コンテスト当日のベンチマーカーの挙動を再現する場合は`-reproduce`をつけてベンチマーカーを実行してください。  
+デフォルトは無効になっています。

--- a/bench/cmd/bench/main.go
+++ b/bench/cmd/bench/main.go
@@ -59,6 +59,7 @@ func main() {
 	flag.StringVar(&option.DataDir, "data-dir", "data", "Data directory")
 	flag.BoolVar(&option.Debug, "debug", false, "Debug mode")
 	flag.BoolVar(&option.StrictPrepare, "strict-prepare", DefaultStrictPrepare, "strict prepare mode. default: true")
+	flag.BoolVar(&option.Reproduce, "reproduce", false, "reproduce contest day mode. default: false")
 
 	// コマンドライン引数のパースを実行
 	// この時点で各フィールドに値が設定されます

--- a/bench/option.go
+++ b/bench/option.go
@@ -22,16 +22,18 @@ type Option struct {
 	DataDir                  string
 	Debug                    bool
 	StrictPrepare            bool
+	Reproduce                bool
 }
 
 func (o Option) String() string {
 	return fmt.Sprintf(
-		"TargetURL: %s, TargetAddr: %s, RequestTimeout: %s, InitializeRequestTimeout: %s, StrictPrepare: %v",
+		"TargetURL: %s, TargetAddr: %s, RequestTimeout: %s, InitializeRequestTimeout: %s, StrictPrepare: %v, ReproduceMode: %v",
 		o.TargetURL,
 		o.TargetAddr,
 		o.RequestTimeout.String(),
 		o.InitializeRequestTimeout.String(),
 		o.StrictPrepare,
+		o.Reproduce,
 	)
 }
 

--- a/bench/scenario_admin_billing.go
+++ b/bench/scenario_admin_billing.go
@@ -89,7 +89,7 @@ func (sc *Scenario) AdminBillingScenario(ctx context.Context, step *isucandar.Be
 					}
 
 					if beforeID != 0 && beforeID < id {
-						return fmt.Errorf("tenant IDが降順ではありません (before:%d got:%d)", beforeID, id)
+						return fmt.Errorf("tenant IDが降順ではありません (before: %d, got: %d)", beforeID, id)
 					}
 					beforeID = id
 

--- a/bench/scenario_admin_billing_validate.go
+++ b/bench/scenario_admin_billing_validate.go
@@ -127,7 +127,7 @@ func (sc *Scenario) AdminBillingValidate(ctx context.Context, step *isucandar.Be
 					resultYen += t.BillingYen
 				}
 				if resultYen != sumYen {
-					return fmt.Errorf("全テナントの合計金額が正しくありません (want: %d, got:%d)", sumYen, resultYen)
+					return fmt.Errorf("全テナントの合計金額が正しくありません (want: %d, got: %d)", sumYen, resultYen)
 				}
 				return nil
 			}),

--- a/bench/scenario_player.go
+++ b/bench/scenario_player.go
@@ -57,7 +57,6 @@ func (sc *Scenario) PlayerScenarioWorker(step *isucandar.BenchmarkStep, p int32,
 
 // 本来意図していた挙動版
 func (sc *Scenario) PlayerScenario(ctx context.Context, step *isucandar.BenchmarkStep, scTag ScenarioTag, tenantName, playerID string) error {
-	AdminLogger.Println("new")
 	report := timeReporter(string(scTag))
 	defer report()
 	sc.ScenarioStart(scTag)
@@ -202,7 +201,6 @@ func (sc *Scenario) PlayerScenario(ctx context.Context, step *isucandar.Benchmar
 
 // 以下は予選開催時の状態
 func (sc *Scenario) PlayerScenarioReproduce(ctx context.Context, step *isucandar.BenchmarkStep, scTag ScenarioTag, tenantName, playerID string) error {
-	AdminLogger.Println("old")
 	report := timeReporter(string(scTag))
 	defer report()
 	sc.ScenarioStart(scTag)

--- a/bench/scenario_player.go
+++ b/bench/scenario_player.go
@@ -55,7 +55,9 @@ func (sc *Scenario) PlayerScenarioWorker(step *isucandar.BenchmarkStep, p int32,
 	}, nil
 }
 
+// 本来意図していた挙動版
 func (sc *Scenario) PlayerScenario(ctx context.Context, step *isucandar.BenchmarkStep, scTag ScenarioTag, tenantName, playerID string) error {
+	AdminLogger.Println("new")
 	report := timeReporter(string(scTag))
 	defer report()
 	sc.ScenarioStart(scTag)
@@ -68,36 +70,34 @@ func (sc *Scenario) PlayerScenario(ctx context.Context, step *isucandar.Benchmar
 	SlowResponseCount := 0
 
 	for {
+	RETRY_CHOOSE_COMP:
 		var competitions []isuports.CompetitionDetail
 		// 大会を取得する
-		for {
-			res, err, txt := GetPlayerCompetitionsAction(ctx, playerAg)
-			msg := fmt.Sprintf("%s %s", playerAc, txt)
-			v := ValidateResponseWithMsg("テナント内の大会情報取得", step, res, err, msg, WithStatusCode(200),
-				WithSuccessResponse(func(r ResponseAPICompetitions) error {
-					competitions = r.Data.Competitions
-					return nil
-				}),
-			)
-			if v.IsEmpty() {
-				sc.AddScoreByScenario(step, ScoreGETPlayerCompetitions, scTag)
-			} else if v.Canceled {
+		res, err, txt := GetPlayerCompetitionsAction(ctx, playerAg)
+		msg := fmt.Sprintf("%s %s", playerAc, txt)
+		v := ValidateResponseWithMsg("テナント内の大会情報取得", step, res, err, msg, WithStatusCode(200),
+			WithSuccessResponse(func(r ResponseAPICompetitions) error {
+				competitions = r.Data.Competitions
 				return nil
-			} else if v.Canceled {
-				// contextの打ち切りでloopを抜ける
-				return nil
-			} else {
-				sc.AddErrorCount()
-				return v
-			}
+			}),
+		)
+		if v.IsEmpty() {
+			sc.AddScoreByScenario(step, ScoreGETPlayerCompetitions, scTag)
+		} else if v.Canceled {
+			return nil
+		} else if v.Canceled {
+			// contextの打ち切りでloopを抜ける
+			return nil
+		} else {
+			sc.AddErrorCount()
+			return v
+		}
 
-			if len(competitions) != 0 {
-				break
-			}
-
-			// NOTE: worker発火直後はcompetitionsが無いので登録されるまで待つ
+		// 大会がなければsleepして選び直す
+		if len(competitions) == 0 {
 			sleepms := 500 + rand.Intn(500)
 			SleepWithCtx(ctx, time.Millisecond*time.Duration(sleepms))
+			goto RETRY_CHOOSE_COMP
 		}
 
 		for i := 0; i < ConstPlayerScenarioCompetitionLoopCount; i++ {
@@ -119,6 +119,8 @@ func (sc *Scenario) PlayerScenario(ctx context.Context, step *isucandar.Benchmar
 			}
 			comp := competitions[compIndex]
 
+			// 大会ランキングを取得する
+			// 20%の確率でrankAfterをつけてもう一度リクエストする
 			playerIDs := []string{}
 			rankAfterCheck := rand.Intn(100) < 20
 			rankAfter := ""
@@ -157,16 +159,16 @@ func (sc *Scenario) PlayerScenario(ctx context.Context, step *isucandar.Benchmar
 				}
 				rankAfterCheck = false // rankAfterCheckは一回だけで良い
 				rankAfter = strconv.Itoa(rand.Intn(len(playerIDs)))
+				sleepms := rand.Intn(500)
+				SleepWithCtx(ctx, time.Millisecond*time.Duration(sleepms))
 			}
 
 			// 大会参加者を何人か見る
-			// もし参加者がいなければ大会を選び直す
-			// 	NOTE: 予選後のメモ
-			// 		予選開催時、考慮漏れのため「空のランキングが返ってきた場合（スコア入稿が完了していない場合）はsleep無しでranking取得を繰り返す」という挙動になっていた
-			// 		そのため想定から外れ、PlayerAPIをほぼ叩かずrankingを叩いてスコアを稼ぐという解法があった。
-			// 		ただし、スコア入稿の速度によってrankingを叩く回数が大きくブレるため、ベンチマークスコアのブレも大きくなる傾向にあった。
+			// 参加者がいなければ大会一覧の取得からやり直す
 			if len(playerIDs) == 0 {
-				continue
+				sleepms := 500 + rand.Intn(500)
+				SleepWithCtx(ctx, time.Millisecond*time.Duration(sleepms))
+				goto RETRY_CHOOSE_COMP
 			}
 
 			playerCount := randomRange([]int{3, 5})
@@ -200,6 +202,7 @@ func (sc *Scenario) PlayerScenario(ctx context.Context, step *isucandar.Benchmar
 
 // 以下は予選開催時の状態
 func (sc *Scenario) PlayerScenarioReproduce(ctx context.Context, step *isucandar.BenchmarkStep, scTag ScenarioTag, tenantName, playerID string) error {
+	AdminLogger.Println("old")
 	report := timeReporter(string(scTag))
 	defer report()
 	sc.ScenarioStart(scTag)

--- a/bench/scenario_player.go
+++ b/bench/scenario_player.go
@@ -31,9 +31,16 @@ func (sc *Scenario) PlayerScenarioWorker(step *isucandar.BenchmarkStep, p int32,
 
 	w, err := worker.NewWorker(
 		func(ctx context.Context, _ int) {
-			if err := sc.PlayerScenario(ctx, step, scTag, tenantName, playerID); err != nil {
-				sc.ScenarioError(scTag, err)
-				SleepWithCtx(ctx, SleepOnError)
+			if sc.Option.Reproduce {
+				if err := sc.PlayerScenarioReproduce(ctx, step, scTag, tenantName, playerID); err != nil {
+					sc.ScenarioError(scTag, err)
+					SleepWithCtx(ctx, SleepOnError)
+				}
+			} else {
+				if err := sc.PlayerScenario(ctx, step, scTag, tenantName, playerID); err != nil {
+					sc.ScenarioError(scTag, err)
+					SleepWithCtx(ctx, SleepOnError)
+				}
 			}
 		},
 		worker.WithLoopCount(1),
@@ -49,6 +56,150 @@ func (sc *Scenario) PlayerScenarioWorker(step *isucandar.BenchmarkStep, p int32,
 }
 
 func (sc *Scenario) PlayerScenario(ctx context.Context, step *isucandar.BenchmarkStep, scTag ScenarioTag, tenantName, playerID string) error {
+	report := timeReporter(string(scTag))
+	defer report()
+	sc.ScenarioStart(scTag)
+
+	playerAc, playerAg, err := sc.GetAccountAndAgent(AccountRolePlayer, tenantName, playerID)
+	if err != nil {
+		return err
+	}
+
+	SlowResponseCount := 0
+
+	for {
+		var competitions []isuports.CompetitionDetail
+		// 大会を取得する
+		for {
+			res, err, txt := GetPlayerCompetitionsAction(ctx, playerAg)
+			msg := fmt.Sprintf("%s %s", playerAc, txt)
+			v := ValidateResponseWithMsg("テナント内の大会情報取得", step, res, err, msg, WithStatusCode(200),
+				WithSuccessResponse(func(r ResponseAPICompetitions) error {
+					competitions = r.Data.Competitions
+					return nil
+				}),
+			)
+			if v.IsEmpty() {
+				sc.AddScoreByScenario(step, ScoreGETPlayerCompetitions, scTag)
+			} else if v.Canceled {
+				return nil
+			} else if v.Canceled {
+				// contextの打ち切りでloopを抜ける
+				return nil
+			} else {
+				sc.AddErrorCount()
+				return v
+			}
+
+			if len(competitions) != 0 {
+				break
+			}
+
+			// NOTE: worker発火直後はcompetitionsが無いので登録されるまで待つ
+			sleepms := 500 + rand.Intn(500)
+			SleepWithCtx(ctx, time.Millisecond*time.Duration(sleepms))
+		}
+
+		for i := 0; i < ConstPlayerScenarioCompetitionLoopCount; i++ {
+			// 大会を一つ選ぶ
+			// 開催中の大会があれば90%でそれを選ぶ
+			compIndex := -1
+			if rand.Intn(100) < 90 {
+				for i, comp := range competitions {
+					if !comp.IsFinished {
+						compIndex = i
+						break
+					}
+				}
+			}
+
+			// なければなんでも良いので一つ選ぶ
+			if compIndex < 0 {
+				compIndex = rand.Intn(len(competitions))
+			}
+			comp := competitions[compIndex]
+
+			playerIDs := []string{}
+			rankAfterCheck := rand.Intn(100) < 20
+			rankAfter := ""
+			for {
+				requestTime := time.Now()
+				res, err, txt := GetPlayerCompetitionRankingAction(ctx, comp.ID, rankAfter, playerAg)
+
+				// 表示に1.2秒以上3回かかったら離脱する
+				if (time.Millisecond * 1200) < time.Since(requestTime) {
+					SlowResponseCount++
+					if 3 <= SlowResponseCount {
+						sc.PlayerDelCountAdd(1)
+						return nil
+					}
+				}
+
+				msg := fmt.Sprintf("%s %s", playerAc, txt)
+				v := ValidateResponseWithMsg("大会内のランキング取得", step, res, err, msg, WithStatusCode(200),
+					WithSuccessResponse(func(r ResponseAPICompetitionRanking) error {
+						for _, rank := range r.Data.Ranks {
+							playerIDs = append(playerIDs, rank.PlayerID)
+						}
+						return nil
+					}),
+				)
+				if v.IsEmpty() {
+					sc.AddScoreByScenario(step, ScoreGETPlayerRanking, scTag)
+				} else if v.Canceled {
+					return nil
+				} else {
+					sc.AddErrorCount()
+					return v
+				}
+				if !rankAfterCheck || len(playerIDs) == 0 {
+					break
+				}
+				rankAfterCheck = false // rankAfterCheckは一回だけで良い
+				rankAfter = strconv.Itoa(rand.Intn(len(playerIDs)))
+			}
+
+			// 大会参加者を何人か見る
+			// もし参加者がいなければ大会を選び直す
+			// 	NOTE: 予選後のメモ
+			// 		予選開催時、考慮漏れのため「空のランキングが返ってきた場合（スコア入稿が完了していない場合）はsleep無しでranking取得を繰り返す」という挙動になっていた
+			// 		そのため想定から外れ、PlayerAPIをほぼ叩かずrankingを叩いてスコアを稼ぐという解法があった。
+			// 		ただし、スコア入稿の速度によってrankingを叩く回数が大きくブレるため、ベンチマークスコアのブレも大きくなる傾向にあった。
+			if len(playerIDs) == 0 {
+				continue
+			}
+
+			playerCount := randomRange([]int{3, 5})
+			for j := 0; j < playerCount; j++ {
+				playerIndex := rand.Intn(len(playerIDs))
+
+				res, err, txt := GetPlayerAction(ctx, playerIDs[playerIndex], playerAg)
+				msg := fmt.Sprintf("%s %s", playerAc, txt)
+				v := ValidateResponseWithMsg("参加者と戦績情報取得", step, res, err, msg, WithStatusCode(200),
+					WithSuccessResponse(func(r ResponseAPIPlayer) error {
+						_ = r
+						return nil
+					}),
+				)
+				if v.IsEmpty() {
+					sc.AddScoreByScenario(step, ScoreGETPlayerDetails, scTag)
+				} else if v.Canceled {
+					return nil
+				} else {
+					sc.AddErrorCount()
+					return v
+				}
+				sleepms := randomRange([]int{1000, 2000})
+				SleepWithCtx(ctx, time.Millisecond*time.Duration(sleepms))
+			}
+		}
+	}
+
+	return nil
+}
+
+// 以下は予選開催時の状態
+func (sc *Scenario) PlayerScenarioReproduce(ctx context.Context, step *isucandar.BenchmarkStep, scTag ScenarioTag, tenantName, playerID string) error {
 	report := timeReporter(string(scTag))
 	defer report()
 	sc.ScenarioStart(scTag)

--- a/bench/scenario_player_validate.go
+++ b/bench/scenario_player_validate.go
@@ -175,10 +175,10 @@ func (sc *Scenario) PlayerValidateScenario(ctx context.Context, step *isucandar.
 			WithContentType("application/json"),
 			WithSuccessResponse(func(r ResponseAPIPlayer) error {
 				if r.Data.Player.ID != pid {
-					return fmt.Errorf("PlayerIDが違います (want:%s got:%s)", pid, r.Data.Player.ID)
+					return fmt.Errorf("PlayerIDが違います (want: %s, got: %s)", pid, r.Data.Player.ID)
 				}
 				if false != r.Data.Player.IsDisqualified {
-					return fmt.Errorf("失格状態が違います playerID: %s (want:%v got:%v)", pid, false, r.Data.Player.IsDisqualified)
+					return fmt.Errorf("失格状態が違います playerID: %s (want: %v, got: %v)", pid, false, r.Data.Player.IsDisqualified)
 				}
 				return nil
 			}),
@@ -200,10 +200,10 @@ func (sc *Scenario) PlayerValidateScenario(ctx context.Context, step *isucandar.
 			WithContentType("application/json"),
 			WithSuccessResponse(func(r ResponseAPIPlayer) error {
 				if r.Data.Player.ID != pid {
-					return fmt.Errorf("PlayerIDが違います (want:%s got:%s)", pid, r.Data.Player.ID)
+					return fmt.Errorf("PlayerIDが違います (want: %s, got: %s)", pid, r.Data.Player.ID)
 				}
 				if false != r.Data.Player.IsDisqualified {
-					return fmt.Errorf("失格状態が違います playerID: %s (want:%v got:%v)", pid, false, r.Data.Player.IsDisqualified)
+					return fmt.Errorf("失格状態が違います playerID: %s (want: %v, got: %v)", pid, false, r.Data.Player.IsDisqualified)
 				}
 				return nil
 			}),
@@ -226,7 +226,7 @@ func (sc *Scenario) PlayerValidateScenario(ctx context.Context, step *isucandar.
 			WithContentType("application/json"),
 			WithSuccessResponse(func(r ResponseAPICompetitionRanking) error {
 				if false != r.Data.Competition.IsFinished {
-					return fmt.Errorf("大会の開催状態が違います CompetitionID:%s (want:%v got:%v)", comp.ID, false, r.Data.Competition.IsFinished)
+					return fmt.Errorf("大会の開催状態が違います CompetitionID: %s (want: %v, got: %v)", comp.ID, false, r.Data.Competition.IsFinished)
 				}
 				beforeRanks = r.Data.Ranks
 				return nil
@@ -317,7 +317,7 @@ func (sc *Scenario) PlayerValidateScenario(ctx context.Context, step *isucandar.
 					return fmt.Errorf("プレイヤーが失格になっていません player.id: %s", r.Data.Player.ID)
 				}
 				if disqualifyingdPlayerID != r.Data.Player.ID {
-					return fmt.Errorf("失格にしたプレイヤーが違います (want:%s, got:%s)", disqualifyingdPlayerID, r.Data.Player.ID)
+					return fmt.Errorf("失格にしたプレイヤーが違います (want: %s, got: %s)", disqualifyingdPlayerID, r.Data.Player.ID)
 				}
 				return nil
 			}),
@@ -375,10 +375,10 @@ func (sc *Scenario) PlayerValidateScenario(ctx context.Context, step *isucandar.
 			WithContentType("application/json"),
 			WithSuccessResponse(func(r ResponseAPICompetitionRanking) error {
 				if false != r.Data.Competition.IsFinished {
-					return fmt.Errorf("大会の開催状態が違います CompetitionID:%s (want:%v got:%v)", comp.ID, false, r.Data.Competition.IsFinished)
+					return fmt.Errorf("大会の開催状態が違います CompetitionID: %s (want: %v, got: %v)", comp.ID, false, r.Data.Competition.IsFinished)
 				}
 				if len(score) != len(r.Data.Ranks) {
-					return fmt.Errorf("大会のランキング数が違います CompetitionID:%s (want:%v got:%v)", comp.ID, len(score), len(r.Data.Ranks))
+					return fmt.Errorf("大会のランキング数が違います CompetitionID: %s (want: %v, got: %v)", comp.ID, len(score), len(r.Data.Ranks))
 				}
 				if diff := cmp.Diff(beforeRanks, r.Data.Ranks); diff == "" {
 					return fmt.Errorf("大会のランキングが更新されていません CompetitionID:%s", comp.ID)
@@ -453,10 +453,10 @@ func (sc *Scenario) PlayerValidateScenario(ctx context.Context, step *isucandar.
 			WithContentType("application/json"),
 			WithSuccessResponse(func(r ResponseAPIPlayer) error {
 				if r.Data.Player.ID != pid {
-					return fmt.Errorf("PlayerIDが違います (want:%s got:%s)", pid, r.Data.Player.ID)
+					return fmt.Errorf("PlayerIDが違います (want: %s, got: %s)", pid, r.Data.Player.ID)
 				}
 				if true != r.Data.Player.IsDisqualified {
-					return fmt.Errorf("失格状態が違います playerID: %s (want:%v got:%v)", pid, true, r.Data.Player.IsDisqualified)
+					return fmt.Errorf("失格状態が違います playerID: %s (want: %v, got: %v)", pid, true, r.Data.Player.IsDisqualified)
 				}
 				return nil
 			}),

--- a/bench/scenario_validation.go
+++ b/bench/scenario_validation.go
@@ -647,7 +647,7 @@ func allAPISuccessCheck(ctx context.Context, sc *Scenario, step *isucandar.Bench
 			WithSuccessResponse(func(r ResponseAPITenantsBilling) error {
 				// 初期データがあるので上限ま取ってこれる
 				if 10 != len(r.Data.Tenants) {
-					return fmt.Errorf("請求ダッシュボードの結果の数が違います (want: %d, got: %d)", len(r.Data.Tenants), 10)
+					return fmt.Errorf("請求ダッシュボードの結果の数が違います (want: %d, got: %d)", 10, len(r.Data.Tenants))
 				}
 				tenantNameMap := make(map[string]struct{})
 				for _, tenant := range r.Data.Tenants {
@@ -783,7 +783,7 @@ func rankingCheck(ctx context.Context, sc *Scenario, step *isucandar.BenchmarkSt
 					pIDs = append(pIDs, pl.ID)
 				}
 				if 101 != len(pIDs) {
-					return fmt.Errorf("追加されたプレイヤーが違います (want:%d got:%d)", 101, len(pIDs))
+					return fmt.Errorf("追加されたプレイヤーが違います (want: %d, got: %d)", 101, len(pIDs))
 				}
 				return nil
 			}),
@@ -1039,7 +1039,7 @@ func rankingCheck(ctx context.Context, sc *Scenario, step *isucandar.BenchmarkSt
 				})
 				for i, rank := range r.Data.Ranks {
 					if rank.Rank != int64(i+1) {
-						return fmt.Errorf("大会のランキングの順位が違います Player:%s(%s) (want: %d位, got: %d位)", rank.PlayerDisplayName, rank.PlayerID, 101-(i+1), rank.Rank)
+						return fmt.Errorf("大会のランキングの順位が違います Player: %s(%s) (want: %d位, got: %d位)", rank.PlayerDisplayName, rank.PlayerID, 101-(i+1), rank.Rank)
 					}
 					if rank.PlayerID != pIDs[i] {
 						return fmt.Errorf("大会のランキングの%d位のプレイヤーが違います (want: %s, got: %s)", i+1, pIDs[i], rank.PlayerID)
@@ -1483,7 +1483,7 @@ func billingAPISuccessCheck(ctx context.Context, sc *Scenario, step *isucandar.B
 					// 初期データと照らし合わせてbillingが合っているか確認
 					index, err := strconv.ParseInt(tenant.ID, 10, 64)
 					if err != nil {
-						return fmt.Errorf("TenantIDの形が違います tenantName:%v (got: %v)", tenant.Name, tenant.ID)
+						return fmt.Errorf("TenantIDの形が違います tenantName: %v (got: %v)", tenant.Name, tenant.ID)
 					}
 					tenantIDs = append(tenantIDs, index)
 					// 初期データからテナントIDで検索
@@ -1499,12 +1499,12 @@ func billingAPISuccessCheck(ctx context.Context, sc *Scenario, step *isucandar.B
 						return fmt.Errorf("初期データに存在しないTenantIDです tenantName:%v (got: %v)", tenant.Name, tenant.ID)
 					}
 					if tenant.BillingYen != initialTenant.Billing {
-						return fmt.Errorf("Billingの結果が違います tenantName:%v (want: %v got: %v)", tenant.Name, initialTenant.Billing, tenant.BillingYen)
+						return fmt.Errorf("Billingの結果が違います tenantName:%v (want: %v, got: %v)", tenant.Name, initialTenant.Billing, tenant.BillingYen)
 					}
 				}
 				sort.Slice(tenantIDs, func(i, j int) bool { return tenantIDs[i] < tenantIDs[j] })
 				if tenantIDs[0] != int64(checkTenantCursor-10) || tenantIDs[len(tenantIDs)-1] != int64(checkTenantCursor-1) {
-					return fmt.Errorf("取得したテナントIDの範囲が違います (want: %v~%v got: %v~%v)",
+					return fmt.Errorf("取得したテナントIDの範囲が違います (want: %v~%v, got: %v~%v)",
 						checkTenantCursor-10, checkTenantCursor-1, tenantIDs[0], tenantIDs[len(tenantIDs)-1],
 					)
 				}

--- a/bench/scenario_validation.go
+++ b/bench/scenario_validation.go
@@ -669,7 +669,7 @@ func allAPISuccessCheck(ctx context.Context, sc *Scenario, step *isucandar.Bench
 	{
 		checkTenantCursor := int64(randomRange([]int{2, 99})) // ID=2~99のどれかのテナントでチェック
 		initDataTenant := sc.InitialDataTenant[checkTenantCursor]
-		_, orgAg, err := sc.GetAccountAndAgent(AccountRoleOrganizer, initDataTenant.TenantName, "organizer")
+		orgAc, orgAg, err := sc.GetAccountAndAgent(AccountRoleOrganizer, initDataTenant.TenantName, "organizer")
 		if err != nil {
 			return err
 		}

--- a/bench/scenario_validation.go
+++ b/bench/scenario_validation.go
@@ -379,7 +379,7 @@ func allAPISuccessCheck(ctx context.Context, sc *Scenario, step *isucandar.Bench
 					WithCacheControlPrivate(),
 					WithSuccessResponse(func(r ResponseAPICompetitionRanking) error {
 						if len(r.Data.Ranks) < beforeRanks {
-							return fmt.Errorf("大会のランキング数が不足しています (expect: %d, got: %d)", beforeRanks, len(r.Data.Ranks))
+							return fmt.Errorf("大会のランキング数が不足しています (want: %d, got: %d)", beforeRanks, len(r.Data.Ranks))
 						}
 						return nil
 					}),

--- a/bench/scenario_validation.go
+++ b/bench/scenario_validation.go
@@ -497,10 +497,6 @@ func allAPISuccessCheck(ctx context.Context, sc *Scenario, step *isucandar.Bench
 		}
 	}
 
-	// 大会の終了(organizer/competition/finish)後は反映まで3sの猶予がある
-	AdminLogger.Println("allAPISuccessCheck sleep 3s")
-	SleepWithCtx(ctx, time.Second*3)
-
 	// テナント管理者API 大会の終了
 	{
 		res, err, txt := PostOrganizerCompetitionFinishAction(ctx, competitionID, orgAg)
@@ -517,6 +513,11 @@ func allAPISuccessCheck(ctx context.Context, sc *Scenario, step *isucandar.Bench
 			return v
 		}
 	}
+
+	// 大会の終了(organizer/competition/finish)後は反映まで3sの猶予がある
+	AdminLogger.Println("allAPISuccessCheck sleep 3s")
+	SleepWithCtx(ctx, time.Second*3)
+
 	// 最終的なランキングが正しいことを確認
 	{
 		// NOTE: 失格者はランキングから除外しない


### PR DESCRIPTION
#225 

- コンテスト当日の挙動を再現する-reproduceオプションを追加
- 内容が空のランキングを取得した際にsleepを含めて大会一覧の取得からリトライするよう変更
- 出力の表記ゆれの修正