### PR TITLE
mysql/mysql-serverのバージョンを8.0.31へ変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     restart: always
 
   mysql:
-    image: mysql/mysql-server:8.0.29
+    image: mysql/mysql-server:8.0.31
     environment:
       - "MYSQL_ROOT_HOST=%"
       - "MYSQL_ROOT_PASSWORD=root"


### PR DESCRIPTION
Docker Hubより8.0.29のイメージが削除されて、
イメージが取得できなくなったため