### PR TITLE
SQLAlchemyのバージョンを固定

### DIFF
--- a/webapp/python/requirements.txt
+++ b/webapp/python/requirements.txt
@@ -2,3 +2,4 @@ Flask
 Flask-SQLAlchemy
 mysql-connector-python
 pyjwt[crypto]
+SQLAlchemy<2.0.0


### PR DESCRIPTION
fix AttributeError: 'Engine' object has no attribute 'execute'