### PR TITLE
mysql-apt-configの更新とapt-getでインストールするmysql-clientのrename

### DIFF
--- a/webapp/go/Dockerfile
+++ b/webapp/go/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get -y upgrade && \
   apt-get install -y wget gcc g++ make sqlite3 && \
-  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
+  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
   apt-get -y install mysql-client

--- a/webapp/go/Dockerfile
+++ b/webapp/go/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
   wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
-  apt-get -y install mysql-client
+  apt-get -y install default-mysql-client
 
 RUN useradd --uid=1001 --create-home isucon
 USER isucon

--- a/webapp/java/Dockerfile
+++ b/webapp/java/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get -y upgrade && \
   apt-get install -y wget gcc g++ make sqlite3 && \
-  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
+  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
   apt-get -y install mysql-client

--- a/webapp/java/Dockerfile
+++ b/webapp/java/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
   wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
-  apt-get -y install mysql-client
+  apt-get -y install default-mysql-client
 
 RUN useradd --uid=1001 --create-home isucon
 USER isucon

--- a/webapp/node/Dockerfile
+++ b/webapp/node/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
   wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
-  apt-get -y install mysql-client
+  apt-get -y install default-mysql-client
 
 RUN useradd --uid=1001 --create-home isucon
 USER isucon

--- a/webapp/node/Dockerfile
+++ b/webapp/node/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get -y upgrade && \
   apt-get install -y wget gcc g++ make sqlite3 libsqlite3-dev && \
-  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
+  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
   apt-get -y install mysql-client

--- a/webapp/perl/Dockerfile
+++ b/webapp/perl/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get -y upgrade && \
   apt-get install -y wget gcc g++ make sqlite3 && \
-  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
+  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
   apt-get -y install mysql-client

--- a/webapp/perl/Dockerfile
+++ b/webapp/perl/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
   wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
-  apt-get -y install mysql-client
+  apt-get -y install default-mysql-client
 
 RUN useradd --uid=1001 --create-home isucon
 USER isucon

--- a/webapp/php/Dockerfile
+++ b/webapp/php/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
   wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
-  apt-get -y install mysql-client && \
+  apt-get -y install default-mysql-client && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/webapp/php/Dockerfile
+++ b/webapp/php/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get -y upgrade && \
   apt-get install -y wget make libzip-dev unzip sqlite3 procps && \
-  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
+  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
   apt-get -y install mysql-client && \

--- a/webapp/python/Dockerfile
+++ b/webapp/python/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get -y upgrade && \
   apt-get install -y wget gcc g++ make sqlite3 && \
-  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
+  wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
   apt-get -y install mysql-client build-essential libssl-dev libffi-dev python3-dev cargo

--- a/webapp/python/Dockerfile
+++ b/webapp/python/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
   wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
-  apt-get -y install mysql-client build-essential libssl-dev libffi-dev python3-dev cargo
+  apt-get -y install default-mysql-client build-essential libssl-dev libffi-dev python3-dev cargo
 
 RUN useradd --uid=1001 --create-home isucon
 USER isucon

--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
   curl -sSfLO https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
-  apt-get -y install sqlite3 mysql-client
+  apt-get -y install sqlite3 default-mysql-client
 
 RUN useradd --uid=1001 --create-home isucon
 USER isucon

--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /tmp
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
   apt-get -y upgrade && \
-  curl -sSfLO https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
+  curl -sSfLO https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
   apt-get -y install ./mysql-apt-config_*_all.deb && \
   apt-get -y update && \
   apt-get -y install sqlite3 mysql-client

--- a/webapp/rust/Dockerfile
+++ b/webapp/rust/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y wget gcc g++ make sqlite3 && \
-    wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb && \
+    wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
     apt-get -y install ./mysql-apt-config_*_all.deb && \
     apt-get -y update && \
     apt-get -y install mysql-client

--- a/webapp/rust/Dockerfile
+++ b/webapp/rust/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     wget -q https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb && \
     apt-get -y install ./mysql-apt-config_*_all.deb && \
     apt-get -y update && \
-    apt-get -y install mysql-client
+    apt-get -y install default-mysql-client
 
 RUN useradd --uid=1001 --create-home isucon
 USER isucon


### PR DESCRIPTION
背景
----
- docker image を build しようとすると、MySQLのパッケージ周りのエラーが出力され build にコケます

再現コマンド

```shell
docker build -t isucon12-qualify:go webapp/go/
```

```shell
...
20.90 Err:2 http://repo.mysql.com/apt/debian bullseye InRelease
20.90   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
21.41 Hit:3 http://deb.debian.org/debian-security bullseye-security InRelease
21.48 Hit:4 http://deb.debian.org/debian bullseye-updates InRelease
21.55 Reading package lists...
21.79 W: GPG error: http://repo.mysql.com/apt/debian bullseye InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
21.79 E: The repository 'http://repo.mysql.com/apt/debian bullseye InRelease' is not signed.
...
```

```shell
...
21.49 Package mysql-client is not available, but is referred to by another package.
21.49 This may mean that the package is missing, has been obsoleted, or
21.49 is only available from another source
21.49
21.52 E: Package 'mysql-client' has no installation candidate
...
```

原因
----
- mysql-apt-config が古い
- mysql-clientの名前が変わった

対応
----
- mysql-apt-config を更新し、 該当箇所でコケないようにします
- default-mysql-client をインストールするように変更し、該当箇所でコケないようにします

補足
----
- mysql-apt-configの際しバージョンは https://dev.mysql.com/downloads/repo/apt/ で確認できます
- perlだけ image build に失敗します